### PR TITLE
Remove: TXT rdata 255 char validation

### DIFF
--- a/api/app/helpers/validator.py
+++ b/api/app/helpers/validator.py
@@ -86,9 +86,6 @@ def is_valid_zone(domain_name):
 
 def is_valid_txt(txt_rdata):
     """Check if it's a valid TXT rdata."""
-    if len(txt_rdata) > 255:
-        raise ValueError("Bad TXT RDATA")
-
     for char in txt_rdata:
         if char not in string.printable:
             raise ValueError("Bad TXT RDATA")

--- a/api/tests/unit/test_validator.py
+++ b/api/tests/unit/test_validator.py
@@ -78,10 +78,7 @@ def test_valid_soa():
 
 def test_valid_txt():
     validator.is_valid_txt("this is sample text")
-    validator.is_valid_txt("a" * 255)
 
-    with pytest.raises(Exception):
-        validator.is_valid_txt("a" * 256)
     with pytest.raises(Exception):
         validator.is_valid_txt("®€")
     with pytest.raises(Exception):


### PR DESCRIPTION
Now TXT rdata can exceed more than 255. Knot will handle the split automatically.