### PR TITLE
Add: build version to health endpoint

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -9,5 +9,12 @@ WORKDIR /dnsagent
 COPY ./requirements.txt /dnsagent/requirements.txt
 RUN pip3 install -r /dnsagent/requirements.txt
 
+ARG BUILD_VERSION
+RUN echo "$BUILD_VERSION" > build-version.txt
+
 COPY . /dnsagent
+
+# check build version
+RUN cat /dnsagent/build-version.txt
+
 RUN pip3 install -e /dnsagent

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,7 +16,13 @@ COPY ./requirements.txt /restknotapi/requirements.txt
 COPY ./servers.yml.example /restknotapi/servers.yml
 
 RUN pip3 install -r /restknotapi/requirements.txt
+
+ARG BUILD_VERSION
+RUN echo "$BUILD_VERSION" > build-version.txt
+
 COPY . /restknotapi
+# check build version
+RUN cat /restknotapi/build-version.txt
 
 RUN apk del gcc linux-headers musl-dev && \
     rm -rf /var/cache/apk/*

--- a/api/app/controllers/api/health.py
+++ b/api/app/controllers/api/health.py
@@ -1,9 +1,12 @@
 from flask_restful import Resource
 
 from app.vendors.rest import response
+from app.helpers import helpers
 
 
 class HealthCheck(Resource):
     def get(self):
-        data = {"check": "100"}
+        build = helpers.read_version("requirements.txt", "build-version.txt")
+
+        data = {"status": "running", "build": build}
         return response(200, data=data, message="OK")

--- a/api/app/helpers/helpers.py
+++ b/api/app/helpers/helpers.py
@@ -1,4 +1,5 @@
 import datetime
+import pathlib
 from functools import wraps
 
 from app.helpers import producer
@@ -72,3 +73,27 @@ def check_producer(f):
             return f(*args, **kwargs)
 
     return decorated_function
+
+
+def read_file(other_file_name, filename):
+    root_dir = pathlib.Path(other_file_name).resolve().parent
+    path = root_dir.joinpath(filename)
+
+    if path.is_file():
+        with open(path, "rb") as f:
+            content = f.read().decode("utf-8")
+            return content
+
+
+def read_version(other_file_name, filename):
+    """Read the the current version or build of the app"""
+    version = ""
+
+    version = read_file(other_file_name, filename)
+    if version:
+        version = version.rstrip()
+
+    if not version:
+        version = "__UNKNOWN__"
+
+    return version

--- a/api/tests/integration/test_health.py
+++ b/api/tests/integration/test_health.py
@@ -3,4 +3,4 @@ class TestHealth:
         res = client.get("/api/health")
         data = res.get_json()
 
-        assert "100" in data["data"]["check"]
+        assert "running" in data["data"]["status"]


### PR DESCRIPTION
It makes us sure that we deployed the correct version.
Without checking many parts.

Fixes #115 
---

Change summaries:

- Update Dockerfile to add `build-version` file
- Update health module to return build-version
- Add related helpers function in helpers module

Tested (on my own repo):

- I have tested that the CI and Release workflow works
- I have tested that the image contains the feature

![image](https://user-images.githubusercontent.com/17734314/109585284-cd226a80-7b35-11eb-9bd3-5f068682ef37.png)

![image](https://user-images.githubusercontent.com/17734314/109585292-d01d5b00-7b35-11eb-892e-f3dcbd2db57c.png)
