### PR TITLE
Fix: Knot DNS socket issue

### DIFF
--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -16,10 +16,10 @@ services:
       - RESTKNOT_LOG_FILE=/restknot-data/restknot-agent.log
     entrypoint: dnsagent start
     volumes:
-        # on CentOS family you need to add `:Z`
-        # .e.g `/var/run/knot/:/var/run/knot/:Z`
+        # on CentOS family you need to add `:z`
+        # .e.g `/var/run/knot/:/var/run/knot/:z`
         - /usr/lib/x86_64-linux-gnu/:/usr/lib/x86_64-linux-gnu/ #ro
         - /etc/knot/:/etc/knot/ #ro
-        - /var/run/knot/:/var/run/knot/:Z
-        - /var/lib/knot/:/var/lib/knot/:Z
-        - ~/restknot-data/:/restknot-data:Z
+        - /var/run/knot/:/var/run/knot/:z
+        - /var/lib/knot/:/var/lib/knot/
+        - ~/restknot-data/:/restknot-data:z

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -29,9 +29,9 @@ services:
             - RESTKNOT_API_KEY=123
         command: gunicorn 'autoapp:app' -b '0.0.0.0:5000' -w 4
         volumes:
-            # on CentOS family you need to add `:Z`
-            - ~/.config/restknot/:/rknt:Z
-            - ~/restknot-data/:/restknot-data:Z
+            # on CentOS family you need to add `:z`
+            - ~/.config/restknot/:/rknt:z
+            - ~/restknot-data/:/restknot-data:z
         links:
             - zookeeper
             - kafka
@@ -50,5 +50,5 @@ services:
         ports:
           - "26257:26257"
         volumes:
-          - /cockroach-data:/cockroach/cockroach-data:Z
+          - /cockroach-data:/cockroach/cockroach-data:z
 


### PR DESCRIPTION
Some of the errors are:
```
KnotCtlError: connection reset (data: None)
ValueError: Can't connect to knot socket: operation not permitted (data: None)
ValueError: Can't connect to knot socket: OS lacked necessary resources (data:
None)
```

The experiment conducted in #117
Fixes #117